### PR TITLE
fix: avoid reinstalling example dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,7 @@ jobs:
         run: echo "editor-react package has no tests"
 
       - name: Test examples
-        run: |
-          cd examples/react
-          pnpm install
-          pnpm build
+        run: pnpm --dir examples/react build
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- stop running a second `pnpm install` inside `examples/react` during CI
- build the example against the workspace install that was already resolved at the repository root
- unblock dependency update PRs that were failing on stale nested `pnpm-lock.yaml` files

## Test plan
- [x] `pnpm install --prefer-frozen-lockfile`
- [x] `pnpm --filter @ssml-utilities/core build`
- [x] `pnpm --filter @ssml-utilities/core type-check`
- [x] `pnpm --filter @ssml-utilities/tag-remover type-check`
- [x] `pnpm --filter @ssml-utilities/tag-remover build`
- [x] `pnpm --filter @ssml-utilities/highlighter build`
- [x] `pnpm --filter @ssml-utilities/editor-react build`
- [x] `pnpm --filter @ssml-utilities/core test --run`
- [x] `pnpm --filter @ssml-utilities/tag-remover test --run`
- [x] `pnpm --filter @ssml-utilities/highlighter test --run`
- [x] `pnpm --dir examples/react build`

Made with [Cursor](https://cursor.com)