### PR TITLE
fix: fail releases when npm publish errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,27 +229,27 @@ jobs:
 
           # メインのパッケージを公開
           cd packages/${{ steps.get-directory.outputs.directory }}
-          pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks || echo "パッケージが既に公開されているか、権限がありません"
+          pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks
 
           # 依存パッケージも公開
           if [[ "${{ github.event.inputs.update_dependent_packages }}" == "true" ]]; then
             if [ "${{ github.event.inputs.package }}" = "@ssml-utilities/core" ]; then
               # highlighter を公開
               cd $GITHUB_WORKSPACE/packages/highlighter
-              pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks || echo "highlighterパッケージが既に公開されているか、権限がありません"
+              pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks
 
               # tag-remover を公開
               cd $GITHUB_WORKSPACE/packages/tag-remover
-              pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks || echo "tag-removerパッケージが既に公開されているか、権限がありません"
+              pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks
               
               # editor-react を公開
               cd $GITHUB_WORKSPACE/packages/editor-react
-              pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks || echo "editor-reactパッケージが既に公開されているか、権限がありません"
+              pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks
             
             elif [ "${{ github.event.inputs.package }}" = "@ssml-utilities/highlighter" ]; then
               # editor-react を公開
               cd $GITHUB_WORKSPACE/packages/editor-react
-              pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks || echo "editor-reactパッケージが既に公開されているか、権限がありません"
+              pnpm publish --access public --tag ${{ github.event.inputs.tag }} --no-git-checks
             fi
           fi
         env:


### PR DESCRIPTION
## Summary
- remove the `|| echo ...` fallbacks from the npm publish commands in `release.yml`
- make the release workflow fail when the main package or any dependent package publish is rejected by npm
- prevent GitHub Releases from being marked successful while the npm registry still stays on the previous version

## Why
- the latest `@ssml-utilities/editor-react@0.9.0` release run created a GitHub release but npm stayed on `0.8.0`
- the workflow log showed `npm publish` returning `E403` (`Two-factor authentication or granular access token with bypass 2fa enabled is required to publish packages.`)
- that error was swallowed by `|| echo ...`, so the workflow incorrectly reported success

## Test plan
- [x] `git diff --check -- .github/workflows/release.yml`
- [x] Verified the workflow change is limited to removing publish error swallowing in `.github/workflows/release.yml`
- [ ] Re-run `Release SSML Utilities Package` and confirm npm publish failures mark the workflow as failed

Made with [Cursor](https://cursor.com)