### PR TITLE
fix: rely on consumer React in editor packages

### DIFF
--- a/.changeset/calm-mails-smile.md
+++ b/.changeset/calm-mails-smile.md
@@ -1,0 +1,6 @@
+---
+"@ssml-utilities/editor-react": patch
+"@ssml-utilities/highlighter": patch
+---
+
+Fix React dependency metadata so published packages rely on consumer-provided React and do not ship unnecessary React-related package constraints.

--- a/packages/editor-react/package.json
+++ b/packages/editor-react/package.json
@@ -33,21 +33,21 @@
     "prepublishOnly": "pnpm run pkg:build"
   },
   "dependencies": {
-    "@ssml-utilities/highlighter": "workspace:*",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "@ssml-utilities/highlighter": "workspace:*"
   },
   "devDependencies": {
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "tsup": "^8.3.6",
     "typescript": "^5.8.3",
     "vite": "^8.0.0",
     "vite-plugin-dts": "^4.5.4"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   }
 }

--- a/packages/editor-react/vite.config.ts
+++ b/packages/editor-react/vite.config.ts
@@ -3,6 +3,9 @@ import react from "@vitejs/plugin-react";
 import dts from "vite-plugin-dts";
 import { resolve } from "path";
 
+const isReactExternal = (id: string) =>
+  /^react($|\/)/.test(id) || /^react-dom($|\/)/.test(id);
+
 export default defineConfig({
   plugins: [react(), dts({ include: ["src"] })],
   build: {
@@ -12,11 +15,14 @@ export default defineConfig({
       fileName: (format) => `index.${format === "es" ? "js" : "cjs"}`,
     },
     rollupOptions: {
-      external: ["react", "react-dom", "@ssml-utilities/highlighter"],
+      external: (id) =>
+        isReactExternal(id) || id === "@ssml-utilities/highlighter",
       output: {
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
+          "react/jsx-runtime": "jsxRuntime",
+          "react/jsx-dev-runtime": "jsxDevRuntime",
           "@ssml-utilities/highlighter": "SSMLHighlighter",
         },
       },

--- a/packages/highlighter/package.json
+++ b/packages/highlighter/package.json
@@ -40,17 +40,12 @@
   },
   "homepage": "https://github.com/jabelic-works/ssml-utilities/tree/main/packages/highlighter#readme",
   "dependencies": {
-    "@rollup/plugin-typescript": "^11.1.6",
     "@ssml-utilities/core": "workspace:*"
-  },
-  "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
+    "@rollup/plugin-typescript": "^11.1.6",
     "@types/jest": "^27.5.2",
-    "@types/react": "^17.0.83",
     "@typescript-eslint/eslint-plugin": "^8.26.0",
     "@typescript-eslint/parser": "^8.26.0",
     "eslint": "^9.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,12 +109,6 @@ importers:
       '@ssml-utilities/highlighter':
         specifier: workspace:*
         version: link:../highlighter
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.18
@@ -125,6 +119,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.25.9))
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.3.6
         version: 8.5.0(@microsoft/api-extractor@7.57.7(@types/node@25.5.0))(postcss@8.5.8)(typescript@5.8.3)
@@ -140,28 +140,19 @@ importers:
 
   packages/highlighter:
     dependencies:
-      '@rollup/plugin-typescript':
-        specifier: ^11.1.6
-        version: 11.1.6(rollup@2.79.2)(tslib@2.8.1)(typescript@5.8.3)
       '@ssml-utilities/core':
         specifier: workspace:*
         version: link:../core
-      react:
-        specifier: ^17.0.0 || ^18.0.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^17.0.0 || ^18.0.0
-        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.13.0
         version: 9.35.0
+      '@rollup/plugin-typescript':
+        specifier: ^11.1.6
+        version: 11.1.6(rollup@2.79.2)(tslib@2.8.1)(typescript@5.8.3)
       '@types/jest':
         specifier: ^27.5.2
         version: 27.5.2
-      '@types/react':
-        specifier: ^17.0.83
-        version: 17.0.88
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.26.0
         version: 8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0)(typescript@5.8.3))(eslint@9.35.0)(typescript@5.8.3)
@@ -1693,14 +1684,8 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
-  '@types/react@17.0.88':
-    resolution: {integrity: sha512-HEOvpzcFWkEcHq4EsTChnpimRc3Lz1/qzYRDFtobFp4obVa6QVjCDMjWmkgxgaTYttNvyjnldY8MUflGp5YiUw==}
-
   '@types/react@18.3.24':
     resolution: {integrity: sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==}
-
-  '@types/scheduler@0.16.8':
-    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -5547,18 +5532,10 @@ snapshots:
     dependencies:
       '@types/react': 18.3.24
 
-  '@types/react@17.0.88':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      '@types/scheduler': 0.16.8
-      csstype: 3.1.3
-
   '@types/react@18.3.24':
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
-
-  '@types/scheduler@0.16.8': {}
 
   '@types/stack-utils@2.0.3': {}
 


### PR DESCRIPTION
## Summary
- move `react` and `react-dom` out of published runtime dependencies for `@ssml-utilities/editor-react`, keep local development copies in `devDependencies`, and widen the peer range to React 18 and 19
- externalize `react`, `react-dom`, and React JSX runtime subpaths in the editor build so published bundles keep using the consumer's React instance
- remove unnecessary React package metadata from `@ssml-utilities/highlighter`, move its build-only Rollup TypeScript plugin to `devDependencies`, and add a changeset for the release workflow

## Test plan
- [x] `pnpm --filter @ssml-utilities/highlighter build`
- [x] `pnpm --filter @ssml-utilities/editor-react build`
- [x] `pnpm --filter @ssml-utilities/editor-react pack --pack-destination ".tmp/pack/editor-react"`
- [x] `pnpm --filter @ssml-utilities/highlighter pack --pack-destination ".tmp/pack/highlighter"`
- [x] install the packed packages into a React 18 consumer and verify a single top-level `react` / `react-dom` resolution with `npm ls react react-dom --prefix ".tmp/consumer-check"`
- [x] install the packed packages into a React 19 consumer and verify a single top-level `react` / `react-dom` resolution with `npm ls react react-dom --prefix ".tmp/consumer-check-19"`

Made with [Cursor](https://cursor.com)