### PR TITLE
feat: add unidic token contract for accent-ir

### DIFF
--- a/packages/accent-ir/README.md
+++ b/packages/accent-ir/README.md
@@ -29,6 +29,8 @@ const google = emitGoogleSSML(accentIR, { voice: "ja-JP-Standard-A" });
 
 `UniDic` を最初の解析 backend として扱うために、`@ssml-utilities/accent-ir` では raw token contract と adapter interface も公開します。
 
+この時点では `UniDic` の実 adapter はまだ未実装です。ここで提供しているのは contract と mock fixture だけです。
+
 ```typescript
 import type {
   UniDicAccentIRAdapter,
@@ -50,7 +52,7 @@ const tokens: UniDicRawToken[] = [
 
 - `AccentIR` には `text`, `reading`, `accent`, `break`, `emphasis` など provider 非依存の意味だけを持たせます。
 - `UniDic` 固有の品詞階層、活用情報、生のアクセント表記、feature 配列は `UniDicRawToken` 側に閉じ込めます。
-- `exampleUniDicRawTokens` は contract 設計用の illustrative fixture で、将来の adapter / test の土台として使えます。
+- `mockUniDicRawTokens` は contract 設計用の mock fixture で、将来の adapter / test の土台として使えます。
 
 ## メモ
 

--- a/packages/accent-ir/src/__tests__/unidic-contract.test.ts
+++ b/packages/accent-ir/src/__tests__/unidic-contract.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { exampleUniDicRawTokens } from "../unidic";
+import { mockUniDicRawTokens } from "../unidic-contract.mock";
 
 describe("UniDic contract", () => {
-  it("illustrative UniDic tokens を export する", () => {
-    expect(exampleUniDicRawTokens).toHaveLength(3);
-    expect(exampleUniDicRawTokens[0]).toMatchObject({
+  it("mock UniDic tokens を export する", () => {
+    expect(mockUniDicRawTokens).toHaveLength(3);
+    expect(mockUniDicRawTokens[0]).toMatchObject({
       surface: "箸",
       reading: "ハシ",
       partOfSpeech: {

--- a/packages/accent-ir/src/index.ts
+++ b/packages/accent-ir/src/index.ts
@@ -327,5 +327,5 @@ export type {
   UniDicPartOfSpeech,
   UniDicRawToken,
   UniDicTokenSource,
-} from "./unidic";
-export { exampleUniDicRawTokens } from "./unidic";
+} from "./unidic-contract";
+export { mockUniDicRawTokens } from "./unidic-contract.mock";

--- a/packages/accent-ir/src/unidic-contract.mock.ts
+++ b/packages/accent-ir/src/unidic-contract.mock.ts
@@ -1,62 +1,8 @@
-import type { AccentIR } from "./index";
+import type { UniDicRawToken } from "./unidic-contract";
 
-export interface UniDicPartOfSpeech {
-  level1: string;
-  level2?: string | null;
-  level3?: string | null;
-  level4?: string | null;
-}
-
-export interface UniDicInflection {
-  type?: string | null;
-  form?: string | null;
-}
-
-export interface UniDicAccentMetadata {
-  accentType?: string | null;
-  accentConnectionType?: string | null;
-  accentModificationType?: string | null;
-}
-
-export interface UniDicTokenSource {
-  dictionary: "unidic";
-  rawFeatures?: readonly string[];
-}
-
-export interface UniDicRawToken {
-  surface: string;
-  lemma?: string | null;
-  orthBase?: string | null;
-  reading?: string | null;
-  pronunciation?: string | null;
-  partOfSpeech: UniDicPartOfSpeech;
-  inflection?: UniDicInflection;
-  accent?: UniDicAccentMetadata;
-  source?: UniDicTokenSource;
-}
-
-export interface UniDicAccentIRAdapterInput {
-  locale?: string;
-  tokens: readonly UniDicRawToken[];
-}
-
-export interface UniDicAccentIRAdapterWarning {
-  code: string;
-  message: string;
-  tokenIndex: number;
-}
-
-export interface UniDicAccentIRAdapterResult {
-  accentIR: AccentIR;
-  warnings: UniDicAccentIRAdapterWarning[];
-}
-
-export interface UniDicAccentIRAdapter {
-  fromUniDic(input: UniDicAccentIRAdapterInput): UniDicAccentIRAdapterResult;
-}
-
-// Illustrative fixture for contract design and tests.
-export const exampleUniDicRawTokens = [
+// Mock tokens for contract design and tests only.
+// These are illustrative fixtures, not the output of a real UniDic runtime.
+export const mockUniDicRawTokens = [
   {
     surface: "箸",
     lemma: "箸",

--- a/packages/accent-ir/src/unidic-contract.ts
+++ b/packages/accent-ir/src/unidic-contract.ts
@@ -1,0 +1,59 @@
+import type { AccentIR } from "./index";
+
+// Contract only. This file does not implement real UniDic parsing or loading.
+// It only defines the shape that a future UniDic adapter should normalize into.
+
+export interface UniDicPartOfSpeech {
+  level1: string;
+  level2?: string | null;
+  level3?: string | null;
+  level4?: string | null;
+}
+
+export interface UniDicInflection {
+  type?: string | null;
+  form?: string | null;
+}
+
+export interface UniDicAccentMetadata {
+  accentType?: string | null;
+  accentConnectionType?: string | null;
+  accentModificationType?: string | null;
+}
+
+export interface UniDicTokenSource {
+  dictionary: "unidic";
+  rawFeatures?: readonly string[];
+}
+
+export interface UniDicRawToken {
+  surface: string;
+  lemma?: string | null;
+  orthBase?: string | null;
+  reading?: string | null;
+  pronunciation?: string | null;
+  partOfSpeech: UniDicPartOfSpeech;
+  inflection?: UniDicInflection;
+  accent?: UniDicAccentMetadata;
+  source?: UniDicTokenSource;
+}
+
+export interface UniDicAccentIRAdapterInput {
+  locale?: string;
+  tokens: readonly UniDicRawToken[];
+}
+
+export interface UniDicAccentIRAdapterWarning {
+  code: string;
+  message: string;
+  tokenIndex: number;
+}
+
+export interface UniDicAccentIRAdapterResult {
+  accentIR: AccentIR;
+  warnings: UniDicAccentIRAdapterWarning[];
+}
+
+export interface UniDicAccentIRAdapter {
+  fromUniDic(input: UniDicAccentIRAdapterInput): UniDicAccentIRAdapterResult;
+}


### PR DESCRIPTION
Closes #139
Refs #135

## Summary
- add initial UniDic raw token and adapter contract types to `@ssml-utilities/accent-ir`
- export an illustrative `exampleUniDicRawTokens` fixture for future adapter and test work
- document the boundary between AccentIR and UniDic-specific metadata in the package README

## Test plan
- [x] `pnpm --filter @ssml-utilities/accent-ir build`
- [x] `pnpm --filter @ssml-utilities/accent-ir test -- --runInBand`
- [x] `pnpm --filter @ssml-utilities/accent-ir type-check`
- [ ] `pnpm --filter @ssml-utilities/accent-ir lint` (repo-level ESLint v9 config mismatch is still a separate issue)


Made with [Cursor](https://cursor.com)