### PR TITLE
feat: add MVP UniDic adapter for AccentIR

### DIFF
--- a/packages/accent-ir/README.md
+++ b/packages/accent-ir/README.md
@@ -29,7 +29,7 @@ const google = emitGoogleSSML(accentIR, { voice: "ja-JP-Standard-A" });
 
 `UniDic` を最初の解析 backend として扱うために、`@ssml-utilities/accent-ir` では raw token contract と adapter interface も公開します。
 
-この時点では `UniDic` の実 adapter はまだ未実装です。ここで提供しているのは contract と mock fixture だけです。
+`MeCab` や辞書のロード自体は行いませんが、すでに正規化された `UniDicRawToken[]` から `AccentIR` を組み立てる MVP adapter は提供します。
 
 ```typescript
 import type {
@@ -48,11 +48,18 @@ const tokens: UniDicRawToken[] = [
 ];
 ```
 
+```typescript
+import { adaptUniDicTokensToAccentIR } from "@ssml-utilities/accent-ir";
+
+const result = adaptUniDicTokensToAccentIR({ tokens });
+```
+
 ### 境界
 
 - `AccentIR` には `text`, `reading`, `accent`, `break`, `emphasis` など provider 非依存の意味だけを持たせます。
 - `UniDic` 固有の品詞階層、活用情報、生のアクセント表記、feature 配列は `UniDicRawToken` 側に閉じ込めます。
 - `mockUniDicRawTokens` は contract 設計用の mock fixture で、将来の adapter / test の土台として使えます。
+- 現在の `adaptUniDicTokensToAccentIR()` は MVP で、名詞、固有名詞、助詞連結、文末 pause などの最小範囲のみを対象にします。
 
 ## メモ
 

--- a/packages/accent-ir/src/__tests__/unidic-adapter.test.ts
+++ b/packages/accent-ir/src/__tests__/unidic-adapter.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { adaptUniDicTokensToAccentIR } from "../unidic-adapter";
+import type { UniDicRawToken } from "../unidic-contract";
+
+describe("UniDic adapter", () => {
+  it("名詞 token を AccentIR の text segment に変換する", () => {
+    const tokens: UniDicRawToken[] = [
+      {
+        surface: "箸",
+        reading: "ハシ",
+        pronunciation: "ハシ",
+        partOfSpeech: {
+          level1: "名詞",
+          level2: "普通名詞",
+          level3: "一般",
+        },
+        accent: {
+          accentType: "1",
+        },
+      },
+    ];
+
+    const result = adaptUniDicTokensToAccentIR({ tokens });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.accentIR).toEqual({
+      locale: "ja-JP",
+      segments: [
+        {
+          type: "text",
+          text: "箸",
+          reading: "はし",
+          accent: { downstep: 1 },
+        },
+      ],
+    });
+  });
+
+  it("固有名詞 token も MVP 範囲として扱う", () => {
+    const tokens: UniDicRawToken[] = [
+      {
+        surface: "東京",
+        reading: "トウキョウ",
+        pronunciation: "トーキョー",
+        partOfSpeech: {
+          level1: "名詞",
+          level2: "固有名詞",
+          level3: "地名",
+        },
+        accent: {
+          accentType: "0",
+        },
+      },
+    ];
+
+    const result = adaptUniDicTokensToAccentIR({ tokens });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.accentIR.segments).toEqual([
+      {
+        type: "text",
+        text: "東京",
+        reading: "とうきょう",
+        accent: { downstep: null },
+      },
+    ]);
+  });
+
+  it("助詞を前の text segment に連結する", () => {
+    const tokens: UniDicRawToken[] = [
+      {
+        surface: "箸",
+        reading: "ハシ",
+        pronunciation: "ハシ",
+        partOfSpeech: {
+          level1: "名詞",
+          level2: "普通名詞",
+          level3: "一般",
+        },
+        accent: {
+          accentType: "1",
+        },
+      },
+      {
+        surface: "を",
+        reading: "ヲ",
+        pronunciation: "オ",
+        partOfSpeech: {
+          level1: "助詞",
+          level2: "格助詞",
+        },
+      },
+      {
+        surface: "持つ",
+        reading: "モツ",
+        pronunciation: "モツ",
+        partOfSpeech: {
+          level1: "動詞",
+          level2: "一般",
+        },
+        accent: {
+          accentType: "1",
+        },
+      },
+    ];
+
+    const result = adaptUniDicTokensToAccentIR({ tokens });
+
+    expect(result.accentIR.segments).toEqual([
+      {
+        type: "text",
+        text: "箸を",
+        reading: "はしを",
+        accent: { downstep: 1 },
+      },
+      {
+        type: "text",
+        text: "持つ",
+        reading: "もつ",
+        accent: { downstep: 1 },
+      },
+    ]);
+  });
+
+  it("文末の句点を break segment に変換する", () => {
+    const tokens: UniDicRawToken[] = [
+      {
+        surface: "持つ",
+        reading: "モツ",
+        pronunciation: "モツ",
+        partOfSpeech: {
+          level1: "動詞",
+          level2: "一般",
+        },
+        accent: {
+          accentType: "1",
+        },
+      },
+      {
+        surface: "。",
+        partOfSpeech: {
+          level1: "補助記号",
+          level2: "句点",
+        },
+      },
+    ];
+
+    const result = adaptUniDicTokensToAccentIR({ tokens });
+
+    expect(result.accentIR.segments).toEqual([
+      {
+        type: "text",
+        text: "持つ",
+        reading: "もつ",
+        accent: { downstep: 1 },
+      },
+      {
+        type: "break",
+        strength: "strong",
+      },
+    ]);
+  });
+});

--- a/packages/accent-ir/src/index.ts
+++ b/packages/accent-ir/src/index.ts
@@ -329,3 +329,7 @@ export type {
   UniDicTokenSource,
 } from "./unidic-contract";
 export { mockUniDicRawTokens } from "./unidic-contract.mock";
+export {
+  adaptUniDicTokensToAccentIR,
+  uniDicAccentIRAdapter,
+} from "./unidic-adapter";

--- a/packages/accent-ir/src/unidic-adapter.ts
+++ b/packages/accent-ir/src/unidic-adapter.ts
@@ -1,0 +1,156 @@
+import type {
+  AccentIR,
+  AccentIRBreakSegment,
+  AccentIRSegment,
+  AccentIRTextSegment,
+  JapanesePitchAccent,
+} from "./index";
+import type {
+  UniDicAccentIRAdapter,
+  UniDicAccentIRAdapterInput,
+  UniDicAccentIRAdapterResult,
+  UniDicAccentIRAdapterWarning,
+  UniDicRawToken,
+} from "./unidic-contract";
+
+// MVP adapter only. This does not execute MeCab or load UniDic dictionaries.
+// It converts already-normalized UniDicRawToken arrays into AccentIR.
+
+const SENTENCE_ENDING_PUNCTUATION = new Set(["。", "！", "!", "？", "?"]);
+
+export const adaptUniDicTokensToAccentIR = (
+  input: UniDicAccentIRAdapterInput
+): UniDicAccentIRAdapterResult => {
+  const warnings: UniDicAccentIRAdapterWarning[] = [];
+  const segments: AccentIRSegment[] = [];
+
+  for (const [tokenIndex, token] of input.tokens.entries()) {
+    if (isSentenceEndingPauseToken(token, tokenIndex, input.tokens)) {
+      segments.push({
+        type: "break",
+        strength: "strong",
+      });
+      continue;
+    }
+
+    if (isAttachableParticle(token) && isLastSegmentText(segments)) {
+      const lastSegment = segments[segments.length - 1] as AccentIRTextSegment;
+      mergeParticleIntoSegment(lastSegment, token);
+      continue;
+    }
+
+    const segment = createTextSegmentFromToken(token, tokenIndex, warnings);
+    segments.push(segment);
+  }
+
+  return {
+    accentIR: {
+      locale: input.locale ?? "ja-JP",
+      segments,
+    },
+    warnings,
+  };
+};
+
+export const uniDicAccentIRAdapter: UniDicAccentIRAdapter = {
+  fromUniDic: adaptUniDicTokensToAccentIR,
+};
+
+const createTextSegmentFromToken = (
+  token: UniDicRawToken,
+  tokenIndex: number,
+  warnings: UniDicAccentIRAdapterWarning[]
+): AccentIRTextSegment => {
+  const accent = parseAccent(token, tokenIndex, warnings);
+
+  return {
+    type: "text",
+    text: token.surface,
+    reading: normalizeReading(token.reading),
+    accent,
+  };
+};
+
+const mergeParticleIntoSegment = (
+  segment: AccentIRTextSegment,
+  token: UniDicRawToken
+): void => {
+  segment.text += token.surface;
+
+  const normalizedReading = normalizeReading(token.reading);
+  if (!normalizedReading) {
+    return;
+  }
+
+  segment.reading = `${segment.reading ?? ""}${normalizedReading}`;
+};
+
+const parseAccent = (
+  token: UniDicRawToken,
+  tokenIndex: number,
+  warnings: UniDicAccentIRAdapterWarning[]
+): JapanesePitchAccent | undefined => {
+  const accentType = token.accent?.accentType?.trim();
+
+  if (!accentType || accentType === "*" || accentType === "") {
+    return undefined;
+  }
+
+  if (accentType === "0") {
+    return { downstep: null };
+  }
+
+  const downstep = Number.parseInt(accentType, 10);
+  if (Number.isNaN(downstep)) {
+    warnings.push({
+      code: "UNIDIC_INVALID_ACCENT_TYPE",
+      message: `Could not parse accentType '${accentType}' from UniDic token.`,
+      tokenIndex,
+    });
+    return undefined;
+  }
+
+  return { downstep };
+};
+
+const isAttachableParticle = (token: UniDicRawToken): boolean =>
+  token.partOfSpeech.level1 === "助詞";
+
+const isSentenceEndingPauseToken = (
+  token: UniDicRawToken,
+  tokenIndex: number,
+  tokens: readonly UniDicRawToken[]
+): boolean =>
+  token.partOfSpeech.level1 === "補助記号" &&
+  SENTENCE_ENDING_PUNCTUATION.has(token.surface) &&
+  tokenIndex === tokens.length - 1;
+
+const isLastSegmentText = (
+  segments: readonly AccentIRSegment[]
+): segments is readonly [...AccentIRSegment[], AccentIRTextSegment] =>
+  segments.length > 0 && segments[segments.length - 1]?.type === "text";
+
+const normalizeReading = (reading?: string | null): string | undefined => {
+  if (!reading || reading === "*") {
+    return undefined;
+  }
+
+  return toHiragana(reading);
+};
+
+const toHiragana = (value: string): string =>
+  Array.from(value)
+    .map((char) => {
+      const codePoint = char.codePointAt(0);
+
+      if (!codePoint) {
+        return char;
+      }
+
+      if (codePoint >= 0x30a1 && codePoint <= 0x30f6) {
+        return String.fromCodePoint(codePoint - 0x60);
+      }
+
+      return char;
+    })
+    .join("");


### PR DESCRIPTION
Closes #140
Refs #135

## Summary
- add `adaptUniDicTokensToAccentIR()` and `uniDicAccentIRAdapter` for the first UniDic-to-AccentIR MVP flow
- cover nouns, proper nouns, attachable particles, and sentence-ending pauses with representative tests
- document the MVP adapter scope in the `@ssml-utilities/accent-ir` README

## Test plan
- [x] `pnpm --filter @ssml-utilities/accent-ir build`
- [x] `pnpm --filter @ssml-utilities/accent-ir test -- --runInBand`
- [x] `pnpm --filter @ssml-utilities/accent-ir type-check`
- [ ] `pnpm --filter @ssml-utilities/accent-ir lint` (repo-level ESLint v9 config mismatch is still a separate issue)


Made with [Cursor](https://cursor.com)